### PR TITLE
 antigen-add, antigen-remove, antigen-update

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -21,6 +21,8 @@ antigen-create() {
     list=("${(f)$(< $HOME/.zsh/bundles)}")
     BUNDLES=$(IFS=','; echo "${list[*]}"; IFS=$' \t\n')
 
+
+    [ -e $HOME/.antigen-hs ] || mkdir $HOME/.antigen-hs
     [ -e $HOME/.antigen-hs/MyAntigen.hs ] && rm -f $HOME/.antigen-hs/MyAntigen.hs
 
     HEADER='


### PR DESCRIPTION
I've add the aforementioned functions to init.zsh. While I do understand your philosophy of wanting to keep antigen-hs minimal, I believe that these are indispensible (might be a harsh word to use).
Could you have a look at these commands, and if possible give suggestions?
