### PR TITLE
remove bit in readme about output directory - it's only half implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ sourcing init.zsh:
     ANTIGEN_HS_HOME # This is only set automatically, and is set to the location
                     # of the antigen-hs repository (which by default is
                     # $HOME/.zsh/antigen-hs)
-    ANTIGEN_HS_OUT  # Output directory for cloned repositories and generated
-                    # scripts, defaults to $HOME/.antigen-hs.
     ANTIGEN_HS_MY   # Your configuration file, defaults to
                     # $ANTIGEN_HS_HOME/../MyAntigen.hs
 


### PR DESCRIPTION
As per my comment on the other thread, I forgot that I hadn't yet put the output dir stuff into the haskell side, so that one only works if you manually move the output repo.
