### PR TITLE
Fix docs for loading zsh-history-substring-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bundles =
   [ bundle "Tarrasch/zsh-functional"
   , bundle "Tarrasch/zsh-bd"
   , bundle "zsh-users/zsh-syntax-highlighting"
-  , bundle "zsh-users/zsh-history-substring-search"
+  , (bundle "zsh-users/zsh-history-substring-search") { sourcingStrategy = antigenSourcingStrategy }
 
   -- If you use a plugin that doesn't have a *.plugin.zsh file. You can set a
   -- more liberal sourcing strategy.


### PR DESCRIPTION
See analogous change in Tarrasch/dotfiles#6